### PR TITLE
fix(workflows): filter renovate targets by config

### DIFF
--- a/.github/scripts/renovate-repositories.js
+++ b/.github/scripts/renovate-repositories.js
@@ -1,3 +1,103 @@
+const supportedConfigPaths = [
+	"renovate.json",
+	"renovate.json5",
+	".github/renovate.json",
+	".github/renovate.json5",
+	".gitlab/renovate.json",
+	".gitlab/renovate.json5",
+	".renovaterc",
+	".renovaterc.json",
+	".renovaterc.json5",
+	"package.json",
+];
+
+const rootSupportedConfigPaths = new Set([
+	"renovate.json",
+	"renovate.json5",
+	".renovaterc",
+	".renovaterc.json",
+	".renovaterc.json5",
+]);
+
+const nestedSupportedConfigPaths = new Map([
+	[".github", new Set(["renovate.json", "renovate.json5"])],
+	[".gitlab", new Set(["renovate.json", "renovate.json5"])],
+]);
+
+const hasPackageJsonRenovateConfig = ({ contentData } = {}) => {
+	if (
+		contentData?.type !== "file" ||
+		typeof contentData?.content !== "string" ||
+		contentData.content.length === 0
+	) {
+		return false;
+	}
+
+	try {
+		const decodedContent = Buffer.from(
+			contentData.content.replace(/\s+/g, ""),
+			contentData.encoding ?? "base64",
+		).toString("utf8");
+		const packageJson = JSON.parse(decodedContent);
+
+		return (
+			packageJson !== null &&
+			typeof packageJson === "object" &&
+			!Array.isArray(packageJson) &&
+			packageJson.renovate !== null &&
+			typeof packageJson.renovate === "object" &&
+			!Array.isArray(packageJson.renovate)
+		);
+	} catch {
+		return false;
+	}
+};
+
+const createEligibilityLookupError = (error) =>
+	new Error(
+		`Unable to determine repository eligibility (status: ${error?.status ?? "unknown"})`,
+	);
+
+const listRepositoryEntries = async ({
+	github,
+	repository,
+	path = "",
+} = {}) => {
+	try {
+		const { data } = await github.rest.repos.getContent({
+			owner: repository.owner.login,
+			repo: repository.name,
+			path,
+		});
+
+		return Array.isArray(data) ? data : [data];
+	} catch (error) {
+		if (error?.status === 404) {
+			return [];
+		}
+
+		throw createEligibilityLookupError(error);
+	}
+};
+
+const getRepositoryContent = async ({ github, repository, path } = {}) => {
+	try {
+		const { data } = await github.rest.repos.getContent({
+			owner: repository.owner.login,
+			repo: repository.name,
+			path,
+		});
+
+		return Array.isArray(data) ? null : data;
+	} catch (error) {
+		if (error?.status === 404) {
+			return null;
+		}
+
+		throw createEligibilityLookupError(error);
+	}
+};
+
 const filterCandidateRepositories = ({ repositories = [], owner } = {}) =>
 	[
 		...new Map(
@@ -11,6 +111,146 @@ const filterCandidateRepositories = ({ repositories = [], owner } = {}) =>
 				.map((repository) => [repository.full_name, repository]),
 		).values(),
 	].sort((left, right) => left.full_name.localeCompare(right.full_name));
+
+const hasSupportedRenovateConfig = async ({ github, repository } = {}) => {
+	if (
+		!github?.rest?.repos?.getContent ||
+		!repository?.owner?.login ||
+		!repository?.name
+	) {
+		throw new Error("A GitHub client and repository details are required");
+	}
+
+	const rootEntries = await listRepositoryEntries({
+		github,
+		repository,
+	});
+	const rootEntryNames = new Set(
+		rootEntries
+			.filter((entry) => typeof entry?.name === "string")
+			.map((entry) => entry.name),
+	);
+
+	for (const path of rootSupportedConfigPaths) {
+		if (rootEntryNames.has(path)) {
+			return true;
+		}
+	}
+
+	if (rootEntryNames.has("package.json")) {
+		const packageJsonContent = await getRepositoryContent({
+			github,
+			repository,
+			path: "package.json",
+		});
+
+		if (hasPackageJsonRenovateConfig({ contentData: packageJsonContent })) {
+			return true;
+		}
+	}
+
+	for (const [directoryPath, supportedFiles] of nestedSupportedConfigPaths) {
+		if (!rootEntryNames.has(directoryPath)) {
+			continue;
+		}
+
+		const nestedEntries = await listRepositoryEntries({
+			github,
+			repository,
+			path: directoryPath,
+		});
+
+		if (
+			nestedEntries.some(
+				(entry) =>
+					typeof entry?.name === "string" && supportedFiles.has(entry.name),
+			)
+		) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+const filterEligibleRepositories = async ({
+	github,
+	repositories = [],
+	owner,
+	maxConcurrency = 8,
+} = {}) => {
+	const candidateRepositories = filterCandidateRepositories({
+		repositories,
+		owner,
+	});
+	const eligibleRepositories = [];
+	const workerCount = Math.min(
+		Math.max(1, maxConcurrency),
+		Math.max(1, candidateRepositories.length),
+	);
+	let nextIndex = 0;
+
+	await Promise.all(
+		Array.from({ length: workerCount }, async () => {
+			while (true) {
+				const repositoryIndex = nextIndex;
+				nextIndex += 1;
+
+				if (repositoryIndex >= candidateRepositories.length) {
+					return;
+				}
+
+				const repository = candidateRepositories[repositoryIndex];
+				if (await hasSupportedRenovateConfig({ github, repository })) {
+					eligibleRepositories[repositoryIndex] = repository;
+				}
+			}
+		}),
+	);
+
+	return eligibleRepositories.filter(Boolean);
+};
+
+const resolveEligibleRepositorySelection = async ({
+	github,
+	repositories = [],
+	owner,
+	selectionMap = [],
+	repository,
+	repositoryIndex,
+} = {}) => {
+	const accessibleRepositories = filterCandidateRepositories({
+		repositories,
+		owner,
+	});
+	const selectedRepository = resolveRepositorySelection({
+		repositories: accessibleRepositories.map(toEligibleRepository),
+		selectionMap,
+		repository,
+		repositoryIndex,
+	});
+	const rawSelectedRepository = accessibleRepositories.find(
+		(candidate) => candidate?.id === selectedRepository.id,
+	);
+	const repositoryName =
+		typeof repository === "string" ? repository.trim() : "";
+
+	if (
+		!rawSelectedRepository ||
+		!(await hasSupportedRenovateConfig({
+			github,
+			repository: rawSelectedRepository,
+		}))
+	) {
+		if (repositoryName.length > 0) {
+			throw new Error(`Public repository ${repositoryName} is unavailable`);
+		}
+
+		throw new Error(`Repository index ${repositoryIndex} is unavailable`);
+	}
+
+	return selectedRepository;
+};
 
 const toEligibleRepository = (repository) => ({
 	id: repository.id,
@@ -120,7 +360,12 @@ module.exports = {
 	buildRepositoryMatrix,
 	buildRepositorySelectionMap,
 	filterCandidateRepositories,
+	filterEligibleRepositories,
+	hasPackageJsonRenovateConfig,
+	hasSupportedRenovateConfig,
 	maskPrivateRepositories,
+	resolveEligibleRepositorySelection,
 	resolveRepositorySelection,
+	supportedConfigPaths,
 	toEligibleRepository,
 };

--- a/.github/scripts/renovate-repositories.test.js
+++ b/.github/scripts/renovate-repositories.test.js
@@ -5,7 +5,11 @@ const {
 	buildRepositoryMatrix,
 	buildRepositorySelectionMap,
 	filterCandidateRepositories,
+	filterEligibleRepositories,
+	hasPackageJsonRenovateConfig,
+	hasSupportedRenovateConfig,
 	maskPrivateRepositories,
+	resolveEligibleRepositorySelection,
 	resolveRepositorySelection,
 	toEligibleRepository,
 } = require("./renovate-repositories");
@@ -60,6 +64,251 @@ test("filters to non-archived repositories for the current owner and sorts them"
 	assert.deepEqual(
 		filteredRepositories.map((repository) => repository.full_name),
 		["octo-org/beta", "octo-org/zeta"],
+	);
+});
+
+test("detects package.json-based renovate config", () => {
+	assert.equal(
+		hasPackageJsonRenovateConfig({
+			contentData: {
+				type: "file",
+				encoding: "base64",
+				content: Buffer.from(
+					JSON.stringify({
+						name: "example",
+						renovate: {
+							extends: ["config:recommended"],
+						},
+					}),
+					"utf8",
+				).toString("base64"),
+			},
+		}),
+		true,
+	);
+});
+
+test("ignores package.json files without a renovate section", () => {
+	assert.equal(
+		hasPackageJsonRenovateConfig({
+			contentData: {
+				type: "file",
+				encoding: "base64",
+				content: Buffer.from(
+					JSON.stringify({
+						name: "example",
+						version: "1.0.0",
+					}),
+					"utf8",
+				).toString("base64"),
+			},
+		}),
+		false,
+	);
+});
+
+test("detects supported renovate config files across supported paths", async () => {
+	const requestedPaths = [];
+
+	const result = await hasSupportedRenovateConfig({
+		github: {
+			rest: {
+				repos: {
+					async getContent({ path }) {
+						requestedPaths.push(path);
+						if (path === "") {
+							return {
+								data: [{ name: ".github", type: "dir" }],
+							};
+						}
+
+						if (path === ".github") {
+							return {
+								data: [{ name: "renovate.json5", type: "file" }],
+							};
+						}
+
+						const error = new Error("Not Found");
+						error.status = 404;
+						throw error;
+					},
+				},
+			},
+		},
+		repository: {
+			name: "example",
+			full_name: "octo-org/example",
+			owner: { login: "octo-org" },
+		},
+	});
+
+	assert.equal(result, true);
+	assert.deepEqual(requestedPaths, ["", ".github"]);
+});
+
+test("detects supported package.json renovate config", async () => {
+	const result = await hasSupportedRenovateConfig({
+		github: {
+			rest: {
+				repos: {
+					async getContent({ path }) {
+						if (path === "") {
+							return {
+								data: [{ name: "package.json", type: "file" }],
+							};
+						}
+
+						if (path === "package.json") {
+							return {
+								data: {
+									type: "file",
+									encoding: "base64",
+									content: Buffer.from(
+										JSON.stringify({
+											name: "example",
+											renovate: {
+												extends: ["config:recommended"],
+											},
+										}),
+										"utf8",
+									).toString("base64"),
+								},
+							};
+						}
+
+						const error = new Error("Not Found");
+						error.status = 404;
+						throw error;
+					},
+				},
+			},
+		},
+		repository: {
+			name: "example",
+			full_name: "octo-org/example",
+			owner: { login: "octo-org" },
+		},
+	});
+
+	assert.equal(result, true);
+});
+
+test("does not leak repository names when eligibility lookup fails", async () => {
+	await assert.rejects(
+		hasSupportedRenovateConfig({
+			github: {
+				rest: {
+					repos: {
+						async getContent() {
+							const error = new Error("Forbidden");
+							error.status = 403;
+							throw error;
+						},
+					},
+				},
+			},
+			repository: {
+				name: "private-repo",
+				full_name: "octo-org/private-repo",
+				owner: { login: "octo-org" },
+			},
+		}),
+		/Unable to determine repository eligibility \(status: 403\)/,
+	);
+});
+
+test("filters repositories to supported renovate configs while preserving candidate rules", async () => {
+	const directoryEntries = new Map([
+		["octo-org/alpha:", [{ name: ".renovaterc", type: "file" }]],
+		["octo-org/private-repo:", [{ name: "renovate.json", type: "file" }]],
+		["octo-org/missing-config:", []],
+	]);
+
+	const filteredRepositories = await filterEligibleRepositories({
+		github: {
+			rest: {
+				repos: {
+					async getContent({ owner, repo, path }) {
+						if (path === "") {
+							await new Promise((resolve) =>
+								setTimeout(resolve, repo === "alpha" ? 10 : 0),
+							);
+						}
+
+						const entryKey = `${owner}/${repo}:${path}`;
+						if (directoryEntries.has(entryKey)) {
+							return { data: directoryEntries.get(entryKey) };
+						}
+
+						const error = new Error("Not Found");
+						error.status = 404;
+						throw error;
+					},
+				},
+			},
+		},
+		owner: "octo-org",
+		repositories: [
+			{
+				id: 3,
+				name: "private-repo",
+				full_name: "octo-org/private-repo",
+				owner: { login: "octo-org" },
+				private: true,
+				archived: false,
+				disabled: false,
+			},
+			{
+				id: 1,
+				name: "alpha",
+				full_name: "octo-org/alpha",
+				owner: { login: "octo-org" },
+				private: false,
+				archived: false,
+				disabled: false,
+			},
+			{
+				id: 2,
+				name: "missing-config",
+				full_name: "octo-org/missing-config",
+				owner: { login: "octo-org" },
+				private: false,
+				archived: false,
+				disabled: false,
+			},
+			{
+				id: 4,
+				name: "archived-with-config",
+				full_name: "octo-org/archived-with-config",
+				owner: { login: "octo-org" },
+				private: false,
+				archived: true,
+				disabled: false,
+			},
+			{
+				id: 5,
+				name: "external",
+				full_name: "another-org/external",
+				owner: { login: "another-org" },
+				private: false,
+				archived: false,
+				disabled: false,
+			},
+			{
+				id: 1,
+				name: "alpha",
+				full_name: "octo-org/alpha",
+				owner: { login: "octo-org" },
+				private: false,
+				archived: false,
+				disabled: false,
+			},
+		],
+	});
+
+	assert.deepEqual(
+		filteredRepositories.map((repository) => repository.full_name),
+		["octo-org/alpha", "octo-org/private-repo"],
 	);
 });
 
@@ -256,6 +505,76 @@ test("resolves private repositories from the selection map even if indexes shift
 		full_name: "octo-org/private-repo",
 		private: true,
 	});
+});
+
+test("rejects a selected repository when its supported renovate config is missing", async () => {
+	await assert.rejects(
+		resolveEligibleRepositorySelection({
+			github: {
+				rest: {
+					repos: {
+						async getContent() {
+							const error = new Error("Not Found");
+							error.status = 404;
+							throw error;
+						},
+					},
+				},
+			},
+			owner: "octo-org",
+			repositories: [
+				{
+					id: 1,
+					name: "public-repo",
+					full_name: "octo-org/public-repo",
+					owner: { login: "octo-org" },
+					private: false,
+					archived: false,
+					disabled: false,
+				},
+			],
+			selectionMap: [{ repository: "public-repo", repository_id: 1 }],
+			repository: "public-repo",
+		}),
+		/Public repository public-repo is unavailable/,
+	);
+});
+
+test("rejects a selected private repository index when its supported renovate config is missing", async () => {
+	await assert.rejects(
+		resolveEligibleRepositorySelection({
+			github: {
+				rest: {
+					repos: {
+						async getContent({ path }) {
+							if (path === "") {
+								return { data: [] };
+							}
+
+							const error = new Error("Not Found");
+							error.status = 404;
+							throw error;
+						},
+					},
+				},
+			},
+			owner: "octo-org",
+			repositories: [
+				{
+					id: 2,
+					name: "private-repo",
+					full_name: "octo-org/private-repo",
+					owner: { login: "octo-org" },
+					private: true,
+					archived: false,
+					disabled: false,
+				},
+			],
+			selectionMap: [{ repository_index: 0, repository_id: 2 }],
+			repositoryIndex: "0",
+		}),
+		/Repository index 0 is unavailable/,
+	);
 });
 
 test("rejects attempts to resolve a private repository by name", () => {

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      client_id: ${{ steps.resolve_app_client_id.outputs.client_id }}
       matrix: ${{ steps.list_repositories.outputs.matrix }}
       repository_count: ${{ steps.list_repositories.outputs.repository_count }}
       selection_map: ${{ steps.list_repositories.outputs.selection_map }}
@@ -21,79 +20,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Resolve GitHub App client ID
-        id: resolve_app_client_id
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          CONFIGURED_CLIENT_ID: ${{ vars.APP_CLIENT_ID }}
-          LEGACY_APP_ID: ${{ secrets.APP_ID }}
-          APP_PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        with:
-          script: |
-            const crypto = require("node:crypto");
-            const configuredClientId = (process.env.CONFIGURED_CLIENT_ID ?? "").trim();
-            if (configuredClientId.length > 0) {
-              core.setOutput("client_id", configuredClientId);
-              return;
-            }
-
-            const legacyAppId = (process.env.LEGACY_APP_ID ?? "").trim();
-            if (legacyAppId.length === 0) {
-              throw new Error("Configure vars.APP_CLIENT_ID or secrets.APP_ID with a GitHub App identifier.");
-            }
-
-            if (legacyAppId.startsWith("Iv1.")) {
-              core.setOutput("client_id", legacyAppId);
-              return;
-            }
-
-            if (!/^\d+$/.test(legacyAppId)) {
-              throw new Error("secrets.APP_ID must contain either a GitHub App client ID or a numeric GitHub App ID.");
-            }
-
-            const privateKey = process.env.APP_PRIVATE_KEY ?? "";
-            if (privateKey.length === 0) {
-              throw new Error("Missing GitHub App private key.");
-            }
-
-            core.setSecret(legacyAppId);
-            core.setSecret(privateKey);
-
-            const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
-            const now = Math.floor(Date.now() / 1000);
-            const encodedHeader = encode({ alg: "RS256", typ: "JWT" });
-            const encodedPayload = encode({
-              iat: now - 60,
-              exp: now + 540,
-              iss: legacyAppId,
-            });
-            const signer = crypto.createSign("RSA-SHA256");
-            signer.update(`${encodedHeader}.${encodedPayload}`);
-            signer.end();
-            const jwt = `${encodedHeader}.${encodedPayload}.${signer.sign(privateKey, "base64url")}`;
-            const response = await fetch(`${process.env.GITHUB_API_URL ?? "https://api.github.com"}/app`, {
-              headers: {
-                Accept: "application/vnd.github+json",
-                Authorization: `Bearer ${jwt}`,
-                "X-GitHub-Api-Version": "2022-11-28",
-              },
-            });
-
-            if (!response.ok) {
-              throw new Error(`Unable to resolve the GitHub App client ID (status: ${response.status})`);
-            }
-
-            const app = await response.json();
-            if (typeof app.client_id !== "string" || app.client_id.trim().length === 0) {
-              throw new Error("The GitHub App client ID was missing from the /app response.");
-            }
-
-            core.setOutput("client_id", app.client_id.trim());
       - name: Get token
         id: get_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          client-id: ${{ steps.resolve_app_client_id.outputs.client_id }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: read
@@ -149,7 +80,7 @@ jobs:
         id: get_repository_list_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          client-id: ${{ needs.enumerate_repositories.outputs.client_id }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: read
@@ -189,7 +120,7 @@ jobs:
         id: get_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          client-id: ${{ needs.enumerate_repositories.outputs.client_id }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ steps.resolve_repository.outputs.owner }}
           repositories: ${{ steps.resolve_repository.outputs.repository }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -107,7 +107,7 @@ jobs:
             const {
               buildRepositoryMatrix,
               buildRepositorySelectionMap,
-              filterCandidateRepositories,
+              filterEligibleRepositories,
               maskPrivateRepositories,
               toEligibleRepository,
             } = require(path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/renovate-repositories.js"));
@@ -115,10 +115,11 @@ jobs:
             const repositories = await github.paginate("GET /installation/repositories", {
               per_page: 100,
             });
-            const accessibleRepositories = filterCandidateRepositories({
+            const accessibleRepositories = (await filterEligibleRepositories({
+              github,
               repositories,
               owner: context.repo.owner,
-            }).map(toEligibleRepository);
+            })).map(toEligibleRepository);
 
             maskPrivateRepositories({ core, repositories: accessibleRepositories });
             core.setOutput("matrix", JSON.stringify(buildRepositoryMatrix({
@@ -164,21 +165,17 @@ jobs:
           script: |
             const path = require("node:path");
             const {
-              filterCandidateRepositories,
               maskPrivateRepositories,
-              resolveRepositorySelection,
-              toEligibleRepository,
+              resolveEligibleRepositorySelection,
             } = require(path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/renovate-repositories.js"));
             const repositories = await github.paginate("GET /installation/repositories", {
               per_page: 100,
             });
-            const accessibleRepositories = filterCandidateRepositories({
+            const selectionMap = JSON.parse(process.env.SELECTION_MAP || "[]");
+            const repository = await resolveEligibleRepositorySelection({
+              github,
               repositories,
               owner: context.repo.owner,
-            }).map(toEligibleRepository);
-            const selectionMap = JSON.parse(process.env.SELECTION_MAP || "[]");
-            const repository = resolveRepositorySelection({
-              repositories: accessibleRepositories,
               selectionMap,
               repository: process.env.REPOSITORY,
               repositoryIndex: process.env.REPOSITORY_INDEX,

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,7 +2,7 @@ rules:
   secrets-outside-env:
     config:
       allow:
-        - APP_ID
+        - APP_CLIENT_ID
         - PRIVATE_KEY
         - DOCKERHUB_USERNAME
         - DOCKERHUB_TOKEN


### PR DESCRIPTION
## Summary
- restore supported Renovate config filtering so repositories without local Renovate config are excluded again
- keep the public-name/private-index matrix behavior and selection_map-based resolution intact
- support package.json-based Renovate config detection and avoid leaking private repository names on lookup failures
- require `APP_CLIENT_ID` directly and remove the legacy `APP_ID` compatibility path

## Validation
- node --test .github/scripts/renovate-repositories.test.js