### PR TITLE
fix(workflows): add renovate access diagnostics

### DIFF
--- a/.github/scripts/renovate-repositories.js
+++ b/.github/scripts/renovate-repositories.js
@@ -58,6 +58,34 @@ const createEligibilityLookupError = (error) =>
 		`Unable to determine repository eligibility (status: ${error?.status ?? "unknown"})`,
 	);
 
+const inspectRepositoryCandidate = ({ repository, owner } = {}) => {
+	if (repository?.owner?.login !== owner) {
+		return {
+			candidate: false,
+			reason: "repository owner does not match the workflow owner",
+		};
+	}
+
+	if (repository?.archived) {
+		return {
+			candidate: false,
+			reason: "repository is archived",
+		};
+	}
+
+	if (repository?.disabled) {
+		return {
+			candidate: false,
+			reason: "repository is disabled",
+		};
+	}
+
+	return {
+		candidate: true,
+		reason: "repository is active for the workflow owner",
+	};
+};
+
 const listRepositoryEntries = async ({
 	github,
 	repository,
@@ -104,15 +132,16 @@ const filterCandidateRepositories = ({ repositories = [], owner } = {}) =>
 			(Array.isArray(repositories) ? repositories : [])
 				.filter(
 					(repository) =>
-						repository?.owner?.login === owner &&
-						!repository.archived &&
-						!repository.disabled,
+						inspectRepositoryCandidate({
+							repository,
+							owner,
+						}).candidate,
 				)
 				.map((repository) => [repository.full_name, repository]),
 		).values(),
 	].sort((left, right) => left.full_name.localeCompare(right.full_name));
 
-const hasSupportedRenovateConfig = async ({ github, repository } = {}) => {
+const inspectSupportedRenovateConfig = async ({ github, repository } = {}) => {
 	if (
 		!github?.rest?.repos?.getContent ||
 		!repository?.owner?.login ||
@@ -133,7 +162,11 @@ const hasSupportedRenovateConfig = async ({ github, repository } = {}) => {
 
 	for (const path of rootSupportedConfigPaths) {
 		if (rootEntryNames.has(path)) {
-			return true;
+			return {
+				eligible: true,
+				configPath: path,
+				reason: `supported Renovate config found at ${path}`,
+			};
 		}
 	}
 
@@ -145,7 +178,11 @@ const hasSupportedRenovateConfig = async ({ github, repository } = {}) => {
 		});
 
 		if (hasPackageJsonRenovateConfig({ contentData: packageJsonContent })) {
-			return true;
+			return {
+				eligible: true,
+				configPath: "package.json#renovate",
+				reason: "supported Renovate config found in package.json#renovate",
+			};
 		}
 	}
 
@@ -166,11 +203,65 @@ const hasSupportedRenovateConfig = async ({ github, repository } = {}) => {
 					typeof entry?.name === "string" && supportedFiles.has(entry.name),
 			)
 		) {
-			return true;
+			const matchedEntry = nestedEntries.find(
+				(entry) =>
+					typeof entry?.name === "string" && supportedFiles.has(entry.name),
+			);
+
+			return {
+				eligible: true,
+				configPath: `${directoryPath}/${matchedEntry.name}`,
+				reason: `supported Renovate config found at ${directoryPath}/${matchedEntry.name}`,
+			};
 		}
 	}
 
-	return false;
+	return {
+		eligible: false,
+		configPath: null,
+		reason: "no supported Renovate config was found",
+	};
+};
+
+const hasSupportedRenovateConfig = async ({ github, repository } = {}) => {
+	const inspection = await inspectSupportedRenovateConfig({
+		github,
+		repository,
+	});
+
+	return inspection.eligible;
+};
+
+const inspectRepositoryEligibility = async ({
+	github,
+	repository,
+	owner,
+} = {}) => {
+	const candidateInspection = inspectRepositoryCandidate({
+		repository,
+		owner,
+	});
+
+	if (!candidateInspection.candidate) {
+		return {
+			candidate: false,
+			eligible: false,
+			configPath: null,
+			reason: candidateInspection.reason,
+		};
+	}
+
+	const configInspection = await inspectSupportedRenovateConfig({
+		github,
+		repository,
+	});
+
+	return {
+		candidate: true,
+		eligible: configInspection.eligible,
+		configPath: configInspection.configPath,
+		reason: configInspection.reason,
+	};
 };
 
 const filterEligibleRepositories = async ({
@@ -178,6 +269,7 @@ const filterEligibleRepositories = async ({
 	repositories = [],
 	owner,
 	maxConcurrency = 8,
+	onInspect,
 } = {}) => {
 	const candidateRepositories = filterCandidateRepositories({
 		repositories,
@@ -201,7 +293,17 @@ const filterEligibleRepositories = async ({
 				}
 
 				const repository = candidateRepositories[repositoryIndex];
-				if (await hasSupportedRenovateConfig({ github, repository })) {
+				const inspection = await inspectRepositoryEligibility({
+					github,
+					repository,
+					owner,
+				});
+
+				if (typeof onInspect === "function") {
+					await onInspect({ repository, inspection });
+				}
+
+				if (inspection.eligible) {
 					eligibleRepositories[repositoryIndex] = repository;
 				}
 			}
@@ -250,6 +352,74 @@ const resolveEligibleRepositorySelection = async ({
 	}
 
 	return selectedRepository;
+};
+
+const formatPublicRepositoryEligibilityLog = ({
+	repository,
+	inspection,
+} = {}) => {
+	if (repository?.private || !repository?.full_name || !inspection) {
+		return null;
+	}
+
+	if (inspection.eligible) {
+		return `Including public repository ${repository.full_name} (supported Renovate config: ${inspection.configPath}).`;
+	}
+
+	return `Skipping public repository ${repository.full_name} (${inspection.reason}).`;
+};
+
+const probeDependabotAlertAccess = async ({ github, repository } = {}) => {
+	if (!github?.request || !repository?.owner || !repository?.repository) {
+		throw new Error("A GitHub client and repository details are required");
+	}
+
+	try {
+		await github.request("GET /repos/{owner}/{repo}/dependabot/alerts", {
+			owner: repository.owner,
+			repo: repository.repository,
+			per_page: 1,
+			state: "open",
+			headers: {
+				accept: "application/vnd.github+json",
+			},
+		});
+
+		return {
+			ok: true,
+			status: 200,
+			reason:
+				"Dependabot alerts are accessible with the current installation token",
+		};
+	} catch (error) {
+		const errorMessage = String(error?.message ?? "").toLowerCase();
+
+		if (error?.status === 403) {
+			const isPermissionDenied =
+				errorMessage.includes("resource not accessible by integration") ||
+				errorMessage.includes("must have admin rights to repository");
+
+			if (isPermissionDenied) {
+				return {
+					ok: false,
+					status: 403,
+					reason:
+						"Dependabot alert access is denied for the current installation token",
+				};
+			}
+		}
+
+		if (error?.status === 404) {
+			return {
+				ok: false,
+				status: 404,
+				reason:
+					"Dependabot alerts are unavailable or inaccessible for the current installation token",
+			};
+		}
+
+		throw error;
+	}
 };
 
 const toEligibleRepository = (repository) => ({
@@ -361,9 +531,14 @@ module.exports = {
 	buildRepositorySelectionMap,
 	filterCandidateRepositories,
 	filterEligibleRepositories,
+	formatPublicRepositoryEligibilityLog,
 	hasPackageJsonRenovateConfig,
 	hasSupportedRenovateConfig,
+	inspectRepositoryCandidate,
+	inspectRepositoryEligibility,
+	inspectSupportedRenovateConfig,
 	maskPrivateRepositories,
+	probeDependabotAlertAccess,
 	resolveEligibleRepositorySelection,
 	resolveRepositorySelection,
 	supportedConfigPaths,

--- a/.github/scripts/renovate-repositories.test.js
+++ b/.github/scripts/renovate-repositories.test.js
@@ -6,9 +6,13 @@ const {
 	buildRepositorySelectionMap,
 	filterCandidateRepositories,
 	filterEligibleRepositories,
+	formatPublicRepositoryEligibilityLog,
 	hasPackageJsonRenovateConfig,
 	hasSupportedRenovateConfig,
+	inspectRepositoryCandidate,
+	inspectSupportedRenovateConfig,
 	maskPrivateRepositories,
+	probeDependabotAlertAccess,
 	resolveEligibleRepositorySelection,
 	resolveRepositorySelection,
 	toEligibleRepository,
@@ -64,6 +68,24 @@ test("filters to non-archived repositories for the current owner and sorts them"
 	assert.deepEqual(
 		filteredRepositories.map((repository) => repository.full_name),
 		["octo-org/beta", "octo-org/zeta"],
+	);
+});
+
+test("inspects candidate repositories with explicit skip reasons", () => {
+	assert.deepEqual(
+		inspectRepositoryCandidate({
+			owner: "octo-org",
+			repository: {
+				full_name: "octo-org/archived",
+				owner: { login: "octo-org" },
+				archived: true,
+				disabled: false,
+			},
+		}),
+		{
+			candidate: false,
+			reason: "repository is archived",
+		},
 	);
 });
 
@@ -144,6 +166,45 @@ test("detects supported renovate config files across supported paths", async () 
 
 	assert.equal(result, true);
 	assert.deepEqual(requestedPaths, ["", ".github"]);
+});
+
+test("reports the matching config path when inspecting renovate config eligibility", async () => {
+	const result = await inspectSupportedRenovateConfig({
+		github: {
+			rest: {
+				repos: {
+					async getContent({ path }) {
+						if (path === "") {
+							return {
+								data: [{ name: ".github", type: "dir" }],
+							};
+						}
+
+						if (path === ".github") {
+							return {
+								data: [{ name: "renovate.json5", type: "file" }],
+							};
+						}
+
+						const error = new Error("Not Found");
+						error.status = 404;
+						throw error;
+					},
+				},
+			},
+		},
+		repository: {
+			name: "example",
+			full_name: "octo-org/example",
+			owner: { login: "octo-org" },
+		},
+	});
+
+	assert.deepEqual(result, {
+		eligible: true,
+		configPath: ".github/renovate.json5",
+		reason: "supported Renovate config found at .github/renovate.json5",
+	});
 });
 
 test("detects supported package.json renovate config", async () => {
@@ -309,6 +370,36 @@ test("filters repositories to supported renovate configs while preserving candid
 	assert.deepEqual(
 		filteredRepositories.map((repository) => repository.full_name),
 		["octo-org/alpha", "octo-org/private-repo"],
+	);
+});
+
+test("formats public repository eligibility log lines without exposing private names", () => {
+	assert.equal(
+		formatPublicRepositoryEligibilityLog({
+			repository: {
+				full_name: "octo-org/public-repo",
+				private: false,
+			},
+			inspection: {
+				eligible: true,
+				configPath: ".renovaterc",
+			},
+		}),
+		"Including public repository octo-org/public-repo (supported Renovate config: .renovaterc).",
+	);
+
+	assert.equal(
+		formatPublicRepositoryEligibilityLog({
+			repository: {
+				full_name: "octo-org/private-repo",
+				private: true,
+			},
+			inspection: {
+				eligible: false,
+				reason: "no supported Renovate config was found",
+			},
+		}),
+		null,
 	);
 });
 
@@ -613,5 +704,87 @@ test("converts GitHub API repositories into the persisted workflow format", () =
 			full_name: "octo-org/example",
 			private: true,
 		},
+	);
+});
+
+test("probes effective Dependabot alert access with the current installation token", async () => {
+	const successResult = await probeDependabotAlertAccess({
+		github: {
+			async request(route, params) {
+				assert.equal(route, "GET /repos/{owner}/{repo}/dependabot/alerts");
+				assert.equal(params.owner, "octo-org");
+				assert.equal(params.repo, "public-repo");
+			},
+		},
+		repository: {
+			owner: "octo-org",
+			repository: "public-repo",
+		},
+	});
+
+	assert.deepEqual(successResult, {
+		ok: true,
+		status: 200,
+		reason:
+			"Dependabot alerts are accessible with the current installation token",
+	});
+
+	const forbiddenResult = await probeDependabotAlertAccess({
+		github: {
+			async request() {
+				const error = new Error("Resource not accessible by integration");
+				error.status = 403;
+				throw error;
+			},
+		},
+		repository: {
+			owner: "octo-org",
+			repository: "public-repo",
+		},
+	});
+
+	assert.deepEqual(forbiddenResult, {
+		ok: false,
+		status: 403,
+		reason:
+			"Dependabot alert access is denied for the current installation token",
+	});
+});
+
+test("rethrows unexpected Dependabot alert probe failures", async () => {
+	await assert.rejects(
+		probeDependabotAlertAccess({
+			github: {
+				async request() {
+					const error = new Error("Service Unavailable");
+					error.status = 503;
+					throw error;
+				},
+			},
+			repository: {
+				owner: "octo-org",
+				repository: "public-repo",
+			},
+		}),
+		(error) => error?.status === 503,
+	);
+});
+
+test("rethrows unexpected 403 Dependabot alert probe failures", async () => {
+	await assert.rejects(
+		probeDependabotAlertAccess({
+			github: {
+				async request() {
+					const error = new Error("API rate limit exceeded");
+					error.status = 403;
+					throw error;
+				},
+			},
+			repository: {
+				owner: "octo-org",
+				repository: "public-repo",
+			},
+		}),
+		(error) => error?.status === 403,
 	);
 });

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -39,6 +39,7 @@ jobs:
               buildRepositoryMatrix,
               buildRepositorySelectionMap,
               filterEligibleRepositories,
+              formatPublicRepositoryEligibilityLog,
               maskPrivateRepositories,
               toEligibleRepository,
             } = require(path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/renovate-repositories.js"));
@@ -50,6 +51,16 @@ jobs:
               github,
               repositories,
               owner: context.repo.owner,
+              onInspect: async ({ repository, inspection }) => {
+                const logLine = formatPublicRepositoryEligibilityLog({
+                  repository,
+                  inspection,
+                });
+
+                if (logLine) {
+                  core.info(logLine);
+                }
+              },
             })).map(toEligibleRepository);
 
             maskPrivateRepositories({ core, repositories: accessibleRepositories });
@@ -113,9 +124,16 @@ jobs:
             });
             maskPrivateRepositories({ core, repositories: [repository] });
 
+            if (repository.private) {
+              core.info("Selected private repository for Renovate (details masked).");
+            } else {
+              core.info(`Selected public repository ${repository.full_name} for Renovate.`);
+            }
+
             core.setOutput("owner", repository.owner);
             core.setOutput("repository", repository.repository);
             core.setOutput("full_name", repository.full_name);
+            core.setOutput("private", repository.private ? "true" : "false");
       - name: Get token
         id: get_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -132,6 +150,54 @@ jobs:
           permission-pull-requests: write
           permission-statuses: read
           permission-workflows: write
+      - name: Probe Dependabot alert access
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+          script: |
+            const path = require("node:path");
+            const {
+              probeDependabotAlertAccess,
+            } = require(path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/renovate-repositories.js"));
+
+            const repository = {
+              owner: process.env.REPOSITORY_OWNER,
+              repository: process.env.REPOSITORY_NAME,
+              full_name: process.env.REPOSITORY_FULL_NAME,
+              private: process.env.REPOSITORY_PRIVATE === "true",
+            };
+            const repositoryLabel = repository.private
+              ? "selected private repository"
+              : `public repository ${repository.full_name}`;
+            let probeResult;
+
+            try {
+              probeResult = await probeDependabotAlertAccess({
+                github,
+                repository,
+              });
+            } catch (error) {
+              core.warning(
+                `Dependabot alert access probe errored for ${repositoryLabel} (status: ${error?.status ?? "unknown"}). ${error?.message ?? "Unexpected API failure."} Renovate will continue.`,
+              );
+              return;
+            }
+
+            if (probeResult.ok) {
+              core.info(
+                `Dependabot alert access probe succeeded for ${repositoryLabel}. ${probeResult.reason}.`,
+              );
+              return;
+            }
+
+            core.warning(
+              `Dependabot alert access probe failed for ${repositoryLabel}. ${probeResult.reason}. Renovate will continue.`,
+            );
+        env:
+          REPOSITORY_FULL_NAME: ${{ steps.resolve_repository.outputs.full_name }}
+          REPOSITORY_NAME: ${{ steps.resolve_repository.outputs.repository }}
+          REPOSITORY_OWNER: ${{ steps.resolve_repository.outputs.owner }}
+          REPOSITORY_PRIVATE: ${{ steps.resolve_repository.outputs.private }}
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@6a9df9227eeb83af9a5abef6890bbb0c9068f436 # v46.1.11
         with:


### PR DESCRIPTION
## Summary
- add an explicit Dependabot alerts access probe so each Renovate job logs whether the current installation token can actually reach the alerts API
- add clearer public-repository eligibility logging during enumeration and selection without exposing private repository names
- cover the new eligibility and access diagnostics helpers with regression tests

## Validation
- node --test .github/scripts/renovate-repositories.test.js
