### PR TITLE
fix(workflows): debug renovate-bot runs

### DIFF
--- a/.github/scripts/renovate-repositories.js
+++ b/.github/scripts/renovate-repositories.js
@@ -58,6 +58,27 @@ const createEligibilityLookupError = (error) =>
 		`Unable to determine repository eligibility (status: ${error?.status ?? "unknown"})`,
 	);
 
+const debugLogLevelRepository = "chalharu/renovate-bot";
+
+const resolveRepositoryLogLevel = ({ repository } = {}) =>
+	repository?.full_name === debugLogLevelRepository ? "debug" : "warn";
+
+const formatRepositoryLogLevelLog = ({ repository, logLevel } = {}) => {
+	if (!repository || typeof logLevel !== "string") {
+		return null;
+	}
+
+	if (repository.private) {
+		return "Using configured Renovate log level for selected private repository (details masked).";
+	}
+
+	if (!repository.full_name) {
+		return null;
+	}
+
+	return `Using Renovate log level ${logLevel} for public repository ${repository.full_name}.`;
+};
+
 const inspectRepositoryCandidate = ({ repository, owner } = {}) => {
 	if (repository?.owner?.login !== owner) {
 		return {
@@ -532,6 +553,7 @@ module.exports = {
 	filterCandidateRepositories,
 	filterEligibleRepositories,
 	formatPublicRepositoryEligibilityLog,
+	formatRepositoryLogLevelLog,
 	hasPackageJsonRenovateConfig,
 	hasSupportedRenovateConfig,
 	inspectRepositoryCandidate,
@@ -540,6 +562,7 @@ module.exports = {
 	maskPrivateRepositories,
 	probeDependabotAlertAccess,
 	resolveEligibleRepositorySelection,
+	resolveRepositoryLogLevel,
 	resolveRepositorySelection,
 	supportedConfigPaths,
 	toEligibleRepository,

--- a/.github/scripts/renovate-repositories.test.js
+++ b/.github/scripts/renovate-repositories.test.js
@@ -7,6 +7,7 @@ const {
 	filterCandidateRepositories,
 	filterEligibleRepositories,
 	formatPublicRepositoryEligibilityLog,
+	formatRepositoryLogLevelLog,
 	hasPackageJsonRenovateConfig,
 	hasSupportedRenovateConfig,
 	inspectRepositoryCandidate,
@@ -14,6 +15,7 @@ const {
 	maskPrivateRepositories,
 	probeDependabotAlertAccess,
 	resolveEligibleRepositorySelection,
+	resolveRepositoryLogLevel,
 	resolveRepositorySelection,
 	toEligibleRepository,
 } = require("./renovate-repositories");
@@ -400,6 +402,50 @@ test("formats public repository eligibility log lines without exposing private n
 			},
 		}),
 		null,
+	);
+});
+
+test("resolves repository log levels with a repository-specific override", () => {
+	assert.equal(
+		resolveRepositoryLogLevel({
+			repository: {
+				full_name: "chalharu/renovate-bot",
+			},
+		}),
+		"debug",
+	);
+
+	assert.equal(
+		resolveRepositoryLogLevel({
+			repository: {
+				full_name: "octo-org/public-repo",
+			},
+		}),
+		"warn",
+	);
+});
+
+test("formats repository log level lines without exposing private names", () => {
+	assert.equal(
+		formatRepositoryLogLevelLog({
+			repository: {
+				full_name: "chalharu/renovate-bot",
+				private: false,
+			},
+			logLevel: "debug",
+		}),
+		"Using Renovate log level debug for public repository chalharu/renovate-bot.",
+	);
+
+	assert.equal(
+		formatRepositoryLogLevelLog({
+			repository: {
+				full_name: "octo-org/private-repo",
+				private: true,
+			},
+			logLevel: "warn",
+		}),
+		"Using configured Renovate log level for selected private repository (details masked).",
 	);
 });
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -107,8 +107,10 @@ jobs:
           script: |
             const path = require("node:path");
             const {
+              formatRepositoryLogLevelLog,
               maskPrivateRepositories,
               resolveEligibleRepositorySelection,
+              resolveRepositoryLogLevel,
             } = require(path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/renovate-repositories.js"));
             const repositories = await github.paginate("GET /installation/repositories", {
               per_page: 100,
@@ -123,6 +125,7 @@ jobs:
               repositoryIndex: process.env.REPOSITORY_INDEX,
             });
             maskPrivateRepositories({ core, repositories: [repository] });
+            const logLevel = resolveRepositoryLogLevel({ repository });
 
             if (repository.private) {
               core.info("Selected private repository for Renovate (details masked).");
@@ -130,10 +133,20 @@ jobs:
               core.info(`Selected public repository ${repository.full_name} for Renovate.`);
             }
 
+            const logLevelMessage = formatRepositoryLogLevelLog({
+              repository,
+              logLevel,
+            });
+
+            if (logLevelMessage) {
+              core.info(logLevelMessage);
+            }
+
             core.setOutput("owner", repository.owner);
             core.setOutput("repository", repository.repository);
             core.setOutput("full_name", repository.full_name);
             core.setOutput("private", repository.private ? "true" : "false");
+            core.setOutput("log_level", logLevel);
       - name: Get token
         id: get_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -203,7 +216,7 @@ jobs:
         with:
           # Managed by Renovate via renovate.json customManagers.
           configurationFile: renovate.json
-          renovate-version: 43.141.5
+          renovate-version: 43.141.3
           token: '${{ steps.get_token.outputs.token }}'
         env:
           RENOVATE_AUTODISCOVER: "false"
@@ -212,4 +225,4 @@ jobs:
           RENOVATE_ONBOARDING: "false"
           RENOVATE_PLATFORM_COMMIT: "true"
           RENOVATE_HOST_RULES: '[{"matchHost":"dhi.io","hostType":"docker","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'
-          LOG_LEVEL: warn
+          LOG_LEVEL: ${{ steps.resolve_repository.outputs.log_level }}


### PR DESCRIPTION
## Summary
- pin the central Renovate workflow back to 43.141.3
- resolve a per-repository Renovate log level so only chalharu/renovate-bot runs at debug
- keep the new log-level logging private-safe and cover it with regression tests

## Testing
- node --test .github/scripts/renovate-repositories.test.js