### PR TITLE
fix(workflows): grant renovate status writes

### DIFF
--- a/.github/scripts/renovate-repositories.test.js
+++ b/.github/scripts/renovate-repositories.test.js
@@ -1,4 +1,6 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const test = require("node:test");
 
 const {
@@ -447,6 +449,16 @@ test("formats repository log level lines without exposing private names", () => 
 		}),
 		"Using configured Renovate log level for selected private repository (details masked).",
 	);
+});
+
+test("requests write access for commit statuses in the Renovate workflow", () => {
+	const workflow = fs.readFileSync(
+		path.join(__dirname, "../workflows/renovate.yaml"),
+		"utf8",
+	);
+
+	assert.match(workflow, /permission-statuses:\s*write(?:\s|$)/);
+	assert.doesNotMatch(workflow, /permission-statuses:\s*read(?:\s|$)/);
 });
 
 test("builds a mixed repository matrix without exposing private repository names", () => {

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -155,13 +155,13 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ steps.resolve_repository.outputs.owner }}
           repositories: ${{ steps.resolve_repository.outputs.repository }}
-          # Renovate reads both check runs and commit statuses before it can automerge PRs.
+          # Renovate reads check runs and writes commit statuses for branch stability checks.
           permission-checks: read
           permission-contents: write
           permission-vulnerability-alerts: read
           permission-issues: write
           permission-pull-requests: write
-          permission-statuses: read
+          permission-statuses: write
           permission-workflows: write
       - name: Probe Dependabot alert access
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Summary
- grant the Renovate workflow write access to commit statuses for the repository-scoped GitHub App token
- fix the stale dashboard root cause where Renovate aborted after a 403 on POST /statuses and never reached Dependency Dashboard refresh
- add a focused regression test that guards the workflow from regressing permission-statuses back to read

## Testing
- node --test .github/scripts/renovate-repositories.test.js