### PR TITLE
fix(worker): omit null check-run text

### DIFF
--- a/worker/src/decision.test.ts
+++ b/worker/src/decision.test.ts
@@ -221,15 +221,24 @@ describe("check run body shapes", () => {
 			TARGET,
 			"Renovate's built-in stability-days check exists on this commit.",
 		);
+		const queueBody = checkRunBody(queue);
+		const pendingBody = checkRunBody(pending);
+		const successBody = checkRunBody(success);
+		const successUpdateBody = checkRunUpdateBody(success);
 
-		assert.equal(checkRunBody(queue).status, "queued");
-		assert.equal(checkRunBody(pending).status, "in_progress");
+		assert.equal(queueBody.status, "queued");
+		assert.equal(pendingBody.status, "in_progress");
 		assert.equal(
-			(checkRunBody(pending).output as { text: string }).text,
+			(pendingBody.output as { text: string }).text,
 			"<!-- custom-stability-days-jwt:token -->",
 		);
-		assert.equal(checkRunBody(success).status, "completed");
-		assert.equal(checkRunBody(success).conclusion, "success");
-		assert.equal(checkRunUpdateBody(success).conclusion, "success");
+		assert.equal(successBody.status, "completed");
+		assert.equal(successBody.conclusion, "success");
+		assert.equal(successUpdateBody.conclusion, "success");
+		assert.ok(!("text" in (queueBody.output as Record<string, unknown>)));
+		assert.ok(!("text" in (successBody.output as Record<string, unknown>)));
+		assert.ok(
+			!("text" in (successUpdateBody.output as Record<string, unknown>)),
+		);
 	});
 });

--- a/worker/src/decision.ts
+++ b/worker/src/decision.ts
@@ -251,12 +251,21 @@ function checkRunTitle(state: CheckState): string {
 	}
 }
 
-export function checkRunBody(plan: CheckRunPlan): Record<string, unknown> {
+function checkRunOutput(plan: CheckRunPlan): {
+	title: string;
+	summary: string;
+	text?: string;
+} {
 	const output = {
 		title: checkRunTitle(plan.state),
 		summary: plan.summary,
-		text: plan.text,
 	};
+	if (plan.text === null) return output;
+	return { ...output, text: plan.text };
+}
+
+export function checkRunBody(plan: CheckRunPlan): Record<string, unknown> {
+	const output = checkRunOutput(plan);
 	switch (plan.state) {
 		case "queue":
 			return {
@@ -286,11 +295,7 @@ export function checkRunBody(plan: CheckRunPlan): Record<string, unknown> {
 export function checkRunUpdateBody(
 	plan: CheckRunPlan,
 ): Record<string, unknown> {
-	const output = {
-		title: checkRunTitle(plan.state),
-		summary: plan.summary,
-		text: plan.text,
-	};
+	const output = checkRunOutput(plan);
 	switch (plan.state) {
 		case "queue":
 			return { status: "queued", output };

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -530,5 +530,5 @@ interface CheckRun {
 	name: string;
 	status: string;
 	conclusion: string | null;
-	output: { summary: string; text: string | null } | null;
+	output: { summary: string; text?: string | null } | null;
 }


### PR DESCRIPTION
## Summary
- omit `output.text` from check-run payloads when no text is available
- keep internal `null` handling while making outbound GitHub Checks API payloads valid
- add regression coverage for queued and success bodies so they never serialize `text: null`

## Testing
- cd /workspace/worker && npm test
- cd /workspace/worker && npm run typecheck
- cd /workspace/worker && npm run build