### PR TITLE
fix(stability-days): mirror renovate status context

### DIFF
--- a/.github/scripts/renovate-stability-days.js
+++ b/.github/scripts/renovate-stability-days.js
@@ -13,9 +13,9 @@ const INITIAL_QUEUE_SUMMARY =
 const NO_RELEASE_METADATA_SUMMARY =
 	"No release metadata was found in Renovate JSON logs or signed check-run state, and the PR updated timestamp is unavailable.";
 const BUILTIN_CHECK_SUMMARY =
-	"Renovate's built-in stability-days check exists on this commit.";
+	"Renovate's built-in stability-days check/status exists on this commit.";
 const BUILTIN_CHECK_PENDING_SUMMARY =
-	"Renovate's built-in stability-days check has not passed on this commit yet.";
+	"Renovate's built-in stability-days check/status has not passed on this commit yet.";
 
 const normalizeSharedSecret = (secret = "") => {
 	if (typeof secret !== "string") {
@@ -426,10 +426,28 @@ const findLatestCheckRun = ({ checkRuns = [], name } = {}) =>
 		.sort((left, right) => Number(right?.id ?? 0) - Number(left?.id ?? 0))[0] ??
 	null;
 
+const findLatestCommitStatus = ({ statuses = [], context } = {}) =>
+	[...(Array.isArray(statuses) ? statuses : [])]
+		.filter((status) => status?.context === context)
+		.sort(
+			(left, right) =>
+				new Date(right?.updated_at ?? right?.created_at ?? "").getTime() -
+				new Date(left?.updated_at ?? left?.created_at ?? "").getTime(),
+		)[0] ?? null;
+
 const checkRunHasPassingConclusion = (checkRun) =>
 	checkRun?.status === "completed" &&
 	["success", "neutral", "skipped"].includes(
 		String(checkRun?.conclusion ?? "").toLowerCase(),
+	);
+
+const commitStatusHasPassingState = (status) =>
+	String(status?.state ?? "").toLowerCase() === "success";
+
+const builtInStabilityStatusHasPassed = ({ checkRun, commitStatus } = {}) =>
+	Boolean(
+		(checkRun && checkRunHasPassingConclusion(checkRun)) ||
+			(commitStatus && commitStatusHasPassingState(commitStatus)),
 	);
 
 const validateTokenClaims = ({
@@ -609,10 +627,44 @@ const processPullRequest = async ({
 		checkRuns,
 		name: BUILTIN_STABILITY_CHECK_NAME,
 	});
+	const commitStatuses = pullRequest?.statuses_url
+		? await (async () => {
+				const results = [];
+				for (let page = 1; ; page += 1) {
+					const { data } = await github.request(
+						"GET /repos/{owner}/{repo}/commits/{ref}/statuses",
+						{
+							owner,
+							repo,
+							ref: pullRequest.head.sha,
+							per_page: 100,
+							page,
+							headers: {
+								accept: "application/vnd.github+json",
+							},
+						},
+					);
+					const pageStatuses = data ?? [];
+					results.push(...pageStatuses);
+					if (pageStatuses.length < 100) {
+						break;
+					}
+				}
+				return results;
+			})()
+		: [];
+	const builtInCommitStatus = findLatestCommitStatus({
+		statuses: commitStatuses,
+		context: BUILTIN_STABILITY_CHECK_NAME,
+	});
+	const builtInStabilityStatus = builtInCheckRun ?? builtInCommitStatus;
 
 	let plan;
-	if (builtInCheckRun) {
-		plan = checkRunHasPassingConclusion(builtInCheckRun)
+	if (builtInStabilityStatus) {
+		plan = builtInStabilityStatusHasPassed({
+			checkRun: builtInCheckRun,
+			commitStatus: builtInCommitStatus,
+		})
 			? buildBuiltInSuccessPlan({ pullRequest })
 			: buildBuiltInPendingPlan({ pullRequest });
 	} else {
@@ -825,6 +877,7 @@ module.exports = {
 	extractReusablePendingState,
 	firstValidTimestamp,
 	findLatestCheckRun,
+	findLatestCommitStatus,
 	fetchLabelNames,
 	formatStateTokenMarker,
 	normalizeSharedSecret,

--- a/.github/scripts/renovate-stability-days.test.js
+++ b/.github/scripts/renovate-stability-days.test.js
@@ -776,12 +776,84 @@ test("short-circuits to success when the built-in renovate check exists", async 
 	});
 
 	assert.equal(result.state, "success");
-	assert.match(result.summary, /built-in stability-days check exists/);
+	assert.match(result.summary, /built-in stability-days check\/status exists/);
 	assert.equal(
 		calls.at(-1).route,
 		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
 	);
 	assert.equal(calls.at(-1).params.conclusion, "success");
+});
+
+test("short-circuits to success when the built-in renovate status context exists", async () => {
+	const calls = [];
+	const github = {
+		async request(route, params) {
+			calls.push({ route, params });
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/check-runs") {
+				return {
+					data: {
+						check_runs: [
+							{
+								id: 10,
+								name: CUSTOM_CHECK_NAME,
+								status: "in_progress",
+								conclusion: null,
+								output: {
+									summary: "pending",
+									text: null,
+								},
+							},
+						],
+					},
+				};
+			}
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/statuses") {
+				return {
+					data: [
+						{
+							context: BUILTIN_STABILITY_CHECK_NAME,
+							state: "success",
+							created_at: "2026-05-08T18:00:41Z",
+							updated_at: "2026-05-08T18:00:41Z",
+						},
+					],
+				};
+			}
+			if (route === "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}") {
+				return { data: {} };
+			}
+
+			throw new Error(`Unexpected route: ${route}`);
+		},
+	};
+
+	const result = await processPullRequest({
+		github,
+		owner: "octo-org",
+		repo: "example",
+		pullRequest: {
+			number: 42,
+			title: "Update dependency wrangler to v4.88.0",
+			body: "",
+			statuses_url:
+				"https://api.github.com/repos/octo-org/example/statuses/abc123",
+			head: {
+				ref: "renovate/wrangler-4.88.x",
+				sha: "abc123",
+			},
+		},
+		secret: "secret",
+		now: new Date("2026-05-11T02:27:44Z"),
+	});
+
+	assert.equal(result.state, "success");
+	assert.match(result.summary, /built-in stability-days check\/status exists/);
+	assert.equal(
+		calls.at(-1).route,
+		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
+	);
+	assert.equal(calls.at(-1).params.conclusion, "success");
+	assert.equal(calls.at(-1).params.output.text, null);
 });
 
 test("keeps the custom check pending while the built-in renovate check is still pending", async () => {
@@ -848,6 +920,77 @@ test("keeps the custom check pending while the built-in renovate check is still 
 		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
 	);
 	assert.equal(calls.at(-1).params.status, "in_progress");
+});
+
+test("keeps the custom check pending while the built-in renovate status context is pending", async () => {
+	const calls = [];
+	const github = {
+		async request(route, params) {
+			calls.push({ route, params });
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/check-runs") {
+				return {
+					data: {
+						check_runs: [
+							{
+								id: 10,
+								name: CUSTOM_CHECK_NAME,
+								status: "queued",
+								conclusion: null,
+								output: {
+									summary: INITIAL_QUEUE_SUMMARY,
+									text: null,
+								},
+							},
+						],
+					},
+				};
+			}
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/statuses") {
+				return {
+					data: [
+						{
+							context: BUILTIN_STABILITY_CHECK_NAME,
+							state: "pending",
+							created_at: "2026-05-08T11:41:24Z",
+							updated_at: "2026-05-08T11:41:24Z",
+						},
+					],
+				};
+			}
+			if (route === "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}") {
+				return { data: {} };
+			}
+
+			throw new Error(`Unexpected route: ${route}`);
+		},
+	};
+
+	const result = await processPullRequest({
+		github,
+		owner: "octo-org",
+		repo: "example",
+		pullRequest: {
+			number: 42,
+			title: "Update dependency wrangler to v4.88.0",
+			body: "",
+			statuses_url:
+				"https://api.github.com/repos/octo-org/example/statuses/abc123",
+			head: {
+				ref: "renovate/wrangler-4.88.x",
+				sha: "abc123",
+			},
+		},
+		secret: "secret",
+		now: new Date("2026-05-08T11:42:00Z"),
+	});
+
+	assert.equal(result.state, "pending");
+	assert.equal(
+		calls.at(-1).route,
+		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
+	);
+	assert.equal(calls.at(-1).params.status, "in_progress");
+	assert.equal(calls.at(-1).params.output.text, null);
 });
 
 test("paginates check-run lookups until it finds relevant built-in checks", async () => {

--- a/worker/README.md
+++ b/worker/README.md
@@ -45,9 +45,10 @@ Cloudflare Workers 向け TypeScript Worker が入っています。
 `version_created_at` です。待機期間が終わるまでは check は
 `in_progress`、終わったら `completed` + `success` になります。
 
-GitHub が同じ head SHA に対して組み込みの `renovate/stability-days` check を
-持っている場合は、その結果を優先します。組み込み check が成功済みなら
-custom check も success、まだ完了していなければ custom check も pending のままです。
+GitHub が同じ head SHA に対して組み込みの `renovate/stability-days` check または
+status context を持っている場合は、その結果を優先します。組み込み check/status が
+成功済みなら custom check も success、まだ完了していなければ custom check も
+pending のままです。
 
 ## release metadata の扱い
 
@@ -66,6 +67,10 @@ check run にも metadata が無い場合は、PR の `updated_at` / `updatedAt`
 `version_created_at` を生成して署名済み JWT として custom check に保存します。
 PR の `created_at` は release timestamp として使いません。どの経路でも
 `version_created_at` を作れない場合だけ check は queued のままになります。
+
+ただし、Renovate 自身の `renovate/stability-days` が check run ではなく commit
+status として出る場合があります。その場合も Renovate の判定結果を優先し、status が
+success なら custom check も success にします。
 
 1 本の Renovate ブランチに複数更新が含まれる場合は、ログ中で最も新しい
 `releaseTimestamp` を採用します。これにより、まとめられた更新のうち最も若い

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -38,9 +38,9 @@ const INITIAL_QUEUE_SUMMARY =
 const INVALID_METADATA_SUMMARY =
 	"Pending state metadata could not be validated; waiting for the Renovate follow-up workflow to refresh it.";
 const BUILTIN_CHECK_SUMMARY =
-	"Renovate's built-in stability-days check exists on this commit.";
+	"Renovate's built-in stability-days check/status exists on this commit.";
 const BUILTIN_CHECK_PENDING_SUMMARY =
-	"Renovate's built-in stability-days check has not passed on this commit yet.";
+	"Renovate's built-in stability-days check/status has not passed on this commit yet.";
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
@@ -261,14 +261,26 @@ async function reevaluateCheckRun(
 		target.headSha,
 		installationToken,
 	);
+	const commitStatuses = await listCommitStatuses(
+		target.repositoryFullName,
+		target.headSha,
+		installationToken,
+	);
 
 	const existingCheckRun = findLatestCheckRun(checkRuns, CHECK_NAME);
 
-	// If the built-in Renovate stability-days check exists, mirror its state.
+	// If the built-in Renovate stability-days check/status exists, mirror it.
 	const builtInCheckRun = findLatestCheckRun(checkRuns, BUILTIN_CHECK_NAME);
+	const builtInCommitStatus = findLatestCommitStatus(
+		commitStatuses,
+		BUILTIN_CHECK_NAME,
+	);
 
-	if (builtInCheckRun) {
-		const plan = checkRunHasPassingConclusion(builtInCheckRun)
+	if (builtInCheckRun || builtInCommitStatus) {
+		const plan = builtInStabilityStatusHasPassed(
+			builtInCheckRun,
+			builtInCommitStatus,
+		)
 			? builtinSuccessPlan(target, BUILTIN_CHECK_SUMMARY)
 			: builtinPendingPlan(target);
 		return { plan, existingCheckRun };
@@ -394,6 +406,20 @@ function checkRunHasPassingConclusion(checkRun: CheckRun): boolean {
 	);
 }
 
+function commitStatusHasPassingState(status: CommitStatus): boolean {
+	return status.state.toLowerCase() === "success";
+}
+
+function builtInStabilityStatusHasPassed(
+	checkRun: CheckRun | null,
+	commitStatus: CommitStatus | null,
+): boolean {
+	return Boolean(
+		(checkRun && checkRunHasPassingConclusion(checkRun)) ||
+			(commitStatus && commitStatusHasPassingState(commitStatus)),
+	);
+}
+
 function builtinPendingPlan(target: CheckRunTarget): CheckRunPlan {
 	return {
 		repositoryFullName: target.repositoryFullName,
@@ -434,6 +460,24 @@ function findLatestCheckRun(
 	return latest;
 }
 
+function findLatestCommitStatus(
+	statuses: CommitStatus[],
+	context: string,
+): CommitStatus | null {
+	let latest: CommitStatus | null = null;
+	for (const status of statuses) {
+		if (status.context !== context) continue;
+		if (
+			!latest ||
+			new Date(status.updated_at ?? status.created_at).getTime() >
+				new Date(latest.updated_at ?? latest.created_at).getTime()
+		) {
+			latest = status;
+		}
+	}
+	return latest;
+}
+
 async function listCheckRuns(
 	repositoryFullName: string,
 	headSha: string,
@@ -452,6 +496,28 @@ async function listCheckRuns(
 		const pageRuns = response.check_runs ?? [];
 		all.push(...pageRuns);
 		if (pageRuns.length < CHECK_RUNS_PAGE_SIZE) break;
+	}
+	return all;
+}
+
+async function listCommitStatuses(
+	repositoryFullName: string,
+	headSha: string,
+	installationToken: string,
+): Promise<CommitStatus[]> {
+	const all: CommitStatus[] = [];
+	for (let page = 1; ; page++) {
+		const url =
+			`${GITHUB_API_BASE}/repos/${repositoryFullName}/commits/${headSha}/statuses` +
+			`?per_page=${CHECK_RUNS_PAGE_SIZE}&page=${page}`;
+		const pageStatuses =
+			(await githubJsonRequest<CommitStatus[]>(
+				"GET",
+				url,
+				installationToken,
+			)) ?? [];
+		all.push(...pageStatuses);
+		if (pageStatuses.length < CHECK_RUNS_PAGE_SIZE) break;
 	}
 	return all;
 }
@@ -531,4 +597,11 @@ interface CheckRun {
 	status: string;
 	conclusion: string | null;
 	output: { summary: string; text?: string | null } | null;
+}
+
+interface CommitStatus {
+	context: string;
+	state: string;
+	created_at: string;
+	updated_at?: string;
 }


### PR DESCRIPTION
Fixes #444 where `custom-stability-days` remained pending even though Renovate's built-in minimum-release-age signal had passed.

What changed
- Treat built-in `renovate/stability-days` as either a CheckRun or a commit StatusContext.
- Mirror successful built-in stability-days status contexts in the GitHub Actions helper and Cloudflare Worker.
- Keep non-passing built-in stability-days statuses pending for the custom check.
- Document the CheckRun/StatusContext behavior.

Validation
- git --no-pager diff --check
- node --test .github/scripts/renovate-repositories.test.js .github/scripts/renovate-stability-days.test.js
- npx --yes -p node@22 -p npm@10 --c 'cd worker && npm run typecheck && npm test && timeout 300 npm run build'
