### PR TITLE
fix(stability-days): mirror status contexts safely

### DIFF
--- a/.github/scripts/renovate-stability-days.js
+++ b/.github/scripts/renovate-stability-days.js
@@ -13,9 +13,9 @@ const INITIAL_QUEUE_SUMMARY =
 const NO_RELEASE_METADATA_SUMMARY =
 	"No release metadata was found in Renovate JSON logs or signed check-run state, and the PR updated timestamp is unavailable.";
 const BUILTIN_CHECK_SUMMARY =
-	"Renovate's built-in stability-days check exists on this commit.";
+	"Renovate's built-in stability-days check/status exists on this commit.";
 const BUILTIN_CHECK_PENDING_SUMMARY =
-	"Renovate's built-in stability-days check has not passed on this commit yet.";
+	"Renovate's built-in stability-days check/status has not passed on this commit yet.";
 
 const normalizeSharedSecret = (secret = "") => {
 	if (typeof secret !== "string") {
@@ -315,16 +315,24 @@ const buildEvaluationPlan = ({
 	text: formatStateTokenMarker(token),
 });
 
-const buildCheckOutput = ({ plan } = {}) => ({
-	title:
-		plan.state === "queue"
-			? "Waiting for release metadata"
-			: plan.state === "pending"
-				? "Stability waiting period"
-				: "Stability waiting period passed",
-	summary: plan.summary,
-	text: plan.text,
-});
+const buildCheckOutput = ({ plan } = {}) => {
+	const output = {
+		title:
+			plan.state === "queue"
+				? "Waiting for release metadata"
+				: plan.state === "pending"
+					? "Stability waiting period"
+					: "Stability waiting period passed",
+		summary: plan.summary,
+	};
+	if (plan.text == null) {
+		return output;
+	}
+	return {
+		...output,
+		text: plan.text,
+	};
+};
 
 const buildCreateCheckPayload = ({ plan } = {}) =>
 	plan.state === "success"
@@ -426,11 +434,28 @@ const findLatestCheckRun = ({ checkRuns = [], name } = {}) =>
 		.sort((left, right) => Number(right?.id ?? 0) - Number(left?.id ?? 0))[0] ??
 	null;
 
+const commitStatusTimestamp = (status) => {
+	const timestamp = new Date(status?.updated_at ?? status?.created_at ?? "");
+	return Number.isNaN(timestamp.getTime()) ? 0 : timestamp.getTime();
+};
+
+const findLatestCommitStatus = ({ statuses = [], context } = {}) =>
+	[...(Array.isArray(statuses) ? statuses : [])]
+		.filter((status) => status?.context === context)
+		.sort(
+			(left, right) =>
+				commitStatusTimestamp(right) - commitStatusTimestamp(left) ||
+				Number(right?.id ?? 0) - Number(left?.id ?? 0),
+		)[0] ?? null;
+
 const checkRunHasPassingConclusion = (checkRun) =>
 	checkRun?.status === "completed" &&
 	["success", "neutral", "skipped"].includes(
 		String(checkRun?.conclusion ?? "").toLowerCase(),
 	);
+
+const commitStatusHasPassingState = (status) =>
+	String(status?.state ?? "").toLowerCase() === "success";
 
 const validateTokenClaims = ({
 	claims,
@@ -601,6 +626,24 @@ const processPullRequest = async ({
 		}
 		return results;
 	})();
+	const commitStatuses = await (async () => {
+		if (!pullRequest?.statuses_url) {
+			return [];
+		}
+
+		const { data } = await github.request(
+			"GET /repos/{owner}/{repo}/commits/{ref}/status",
+			{
+				owner,
+				repo,
+				ref: pullRequest.head.sha,
+				headers: {
+					accept: "application/vnd.github+json",
+				},
+			},
+		);
+		return data?.statuses ?? [];
+	})();
 	const customCheckRun = findLatestCheckRun({
 		checkRuns,
 		name: CUSTOM_CHECK_NAME,
@@ -609,10 +652,18 @@ const processPullRequest = async ({
 		checkRuns,
 		name: BUILTIN_STABILITY_CHECK_NAME,
 	});
+	const builtInCommitStatus = findLatestCommitStatus({
+		statuses: commitStatuses,
+		context: BUILTIN_STABILITY_CHECK_NAME,
+	});
 
 	let plan;
 	if (builtInCheckRun) {
 		plan = checkRunHasPassingConclusion(builtInCheckRun)
+			? buildBuiltInSuccessPlan({ pullRequest })
+			: buildBuiltInPendingPlan({ pullRequest });
+	} else if (builtInCommitStatus) {
+		plan = commitStatusHasPassingState(builtInCommitStatus)
 			? buildBuiltInSuccessPlan({ pullRequest })
 			: buildBuiltInPendingPlan({ pullRequest });
 	} else {
@@ -816,6 +867,7 @@ module.exports = {
 	buildBuiltInPendingPlan,
 	buildQueuePlan,
 	checkRunHasPassingConclusion,
+	commitStatusHasPassingState,
 	collectLoggedBranchUpdates,
 	createPendingStateToken,
 	decodePendingStateToken,
@@ -824,6 +876,7 @@ module.exports = {
 	extractStateTokenMarker,
 	extractReusablePendingState,
 	firstValidTimestamp,
+	findLatestCommitStatus,
 	findLatestCheckRun,
 	fetchLabelNames,
 	formatStateTokenMarker,

--- a/.github/scripts/renovate-stability-days.test.js
+++ b/.github/scripts/renovate-stability-days.test.js
@@ -477,7 +477,7 @@ test("queues when logs, check state, and PR updated_at are missing", async () =>
 	assert.equal(result.summary, NO_RELEASE_METADATA_SUMMARY);
 	assert.equal(calls.at(-1).route, "POST /repos/{owner}/{repo}/check-runs");
 	assert.equal(calls.at(-1).params.status, "queued");
-	assert.equal(calls.at(-1).params.output.text, null);
+	assert.ok(!("text" in calls.at(-1).params.output));
 });
 
 test("reuses an existing no-version check token when logs are missing", async () => {
@@ -776,12 +776,180 @@ test("short-circuits to success when the built-in renovate check exists", async 
 	});
 
 	assert.equal(result.state, "success");
-	assert.match(result.summary, /built-in stability-days check exists/);
+	assert.match(result.summary, /built-in stability-days check\/status exists/);
 	assert.equal(
 		calls.at(-1).route,
 		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
 	);
 	assert.equal(calls.at(-1).params.conclusion, "success");
+	assert.ok(!("text" in calls.at(-1).params.output));
+});
+
+test("short-circuits to success when the built-in renovate status context succeeds", async () => {
+	const calls = [];
+	const github = {
+		async request(route, params) {
+			calls.push({ route, params });
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/check-runs") {
+				return {
+					data: {
+						check_runs: [
+							{
+								id: 10,
+								name: CUSTOM_CHECK_NAME,
+								status: "queued",
+								conclusion: null,
+								output: {
+									summary: INITIAL_QUEUE_SUMMARY,
+									text: null,
+								},
+							},
+						],
+					},
+				};
+			}
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/status") {
+				return {
+					data: {
+						statuses: [
+							{
+								id: 20,
+								context: BUILTIN_STABILITY_CHECK_NAME,
+								state: "pending",
+								description:
+									"Updates have not met minimum release age requirement",
+								updated_at: "2026-05-01T12:00:00Z",
+							},
+							{
+								id: 21,
+								context: BUILTIN_STABILITY_CHECK_NAME,
+								state: "success",
+								description: null,
+								updated_at: "2026-05-02T12:00:00Z",
+							},
+						],
+					},
+				};
+			}
+			if (route === "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}") {
+				return { data: {} };
+			}
+
+			throw new Error(`Unexpected route: ${route}`);
+		},
+	};
+
+	const result = await processPullRequest({
+		github,
+		owner: "octo-org",
+		repo: "example",
+		pullRequest: {
+			number: 42,
+			title: "Update dependency example/dependency to v1.2.3",
+			body: "",
+			statuses_url:
+				"https://api.github.com/repos/octo-org/example/statuses/abc123",
+			head: {
+				ref: "renovate/example",
+				sha: "abc123",
+			},
+		},
+		secret: "secret",
+		now: new Date("2026-05-03T12:00:00Z"),
+	});
+
+	assert.equal(result.state, "success");
+	assert.match(result.summary, /built-in stability-days check\/status exists/);
+	assert.equal(
+		calls.at(-1).route,
+		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
+	);
+	assert.equal(calls.at(-1).params.conclusion, "success");
+	assert.ok(!("text" in calls.at(-1).params.output));
+});
+
+test("prefers a built-in renovate check over a conflicting status context", async () => {
+	const calls = [];
+	const github = {
+		async request(route, params) {
+			calls.push({ route, params });
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/check-runs") {
+				return {
+					data: {
+						check_runs: [
+							{
+								id: 11,
+								name: BUILTIN_STABILITY_CHECK_NAME,
+								status: "in_progress",
+								conclusion: null,
+								output: {
+									summary: "builtin pending",
+									text: null,
+								},
+							},
+							{
+								id: 10,
+								name: CUSTOM_CHECK_NAME,
+								status: "queued",
+								conclusion: null,
+								output: {
+									summary: INITIAL_QUEUE_SUMMARY,
+									text: null,
+								},
+							},
+						],
+					},
+				};
+			}
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/status") {
+				return {
+					data: {
+						statuses: [
+							{
+								id: 20,
+								context: BUILTIN_STABILITY_CHECK_NAME,
+								state: "success",
+								description: null,
+								updated_at: "2026-05-02T12:00:00Z",
+							},
+						],
+					},
+				};
+			}
+			if (route === "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}") {
+				return { data: {} };
+			}
+
+			throw new Error(`Unexpected route: ${route}`);
+		},
+	};
+
+	const result = await processPullRequest({
+		github,
+		owner: "octo-org",
+		repo: "example",
+		pullRequest: {
+			number: 42,
+			title: "Update dependency example/dependency to v1.2.3",
+			body: "",
+			statuses_url:
+				"https://api.github.com/repos/octo-org/example/statuses/abc123",
+			head: {
+				ref: "renovate/example",
+				sha: "abc123",
+			},
+		},
+		secret: "secret",
+		now: new Date("2026-05-03T12:00:00Z"),
+	});
+
+	assert.equal(result.state, "pending");
+	assert.equal(
+		calls.at(-1).route,
+		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
+	);
+	assert.equal(calls.at(-1).params.status, "in_progress");
+	assert.ok(!("text" in calls.at(-1).params.output));
 });
 
 test("keeps the custom check pending while the built-in renovate check is still pending", async () => {
@@ -848,6 +1016,81 @@ test("keeps the custom check pending while the built-in renovate check is still 
 		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
 	);
 	assert.equal(calls.at(-1).params.status, "in_progress");
+	assert.ok(!("text" in calls.at(-1).params.output));
+});
+
+test("keeps the custom check pending while the built-in renovate status context is still pending", async () => {
+	const calls = [];
+	const github = {
+		async request(route, params) {
+			calls.push({ route, params });
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/check-runs") {
+				return {
+					data: {
+						check_runs: [
+							{
+								id: 10,
+								name: CUSTOM_CHECK_NAME,
+								status: "queued",
+								conclusion: null,
+								output: {
+									summary: INITIAL_QUEUE_SUMMARY,
+									text: null,
+								},
+							},
+						],
+					},
+				};
+			}
+			if (route === "GET /repos/{owner}/{repo}/commits/{ref}/status") {
+				return {
+					data: {
+						statuses: [
+							{
+								id: 20,
+								context: BUILTIN_STABILITY_CHECK_NAME,
+								state: "pending",
+								description: null,
+								updated_at: "2026-05-02T12:00:00Z",
+							},
+						],
+					},
+				};
+			}
+			if (route === "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}") {
+				return { data: {} };
+			}
+
+			throw new Error(`Unexpected route: ${route}`);
+		},
+	};
+
+	const result = await processPullRequest({
+		github,
+		owner: "octo-org",
+		repo: "example",
+		pullRequest: {
+			number: 42,
+			title: "Update dependency example/dependency to v1.2.3",
+			body: "",
+			statuses_url:
+				"https://api.github.com/repos/octo-org/example/statuses/abc123",
+			head: {
+				ref: "renovate/example",
+				sha: "abc123",
+			},
+		},
+		secret: "secret",
+		now: new Date("2026-05-03T12:00:00Z"),
+	});
+
+	assert.equal(result.state, "pending");
+	assert.equal(
+		calls.at(-1).route,
+		"PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}",
+	);
+	assert.equal(calls.at(-1).params.status, "in_progress");
+	assert.ok(!("text" in calls.at(-1).params.output));
 });
 
 test("paginates check-run lookups until it finds relevant built-in checks", async () => {

--- a/worker/README.md
+++ b/worker/README.md
@@ -45,8 +45,9 @@ Cloudflare Workers 向け TypeScript Worker が入っています。
 `version_created_at` です。待機期間が終わるまでは check は
 `in_progress`、終わったら `completed` + `success` になります。
 
-GitHub が同じ head SHA に対して組み込みの `renovate/stability-days` check を
-持っている場合は、その結果を優先します。組み込み check が成功済みなら
+GitHub が同じ head SHA に対して組み込みの `renovate/stability-days` を
+持っている場合は、その結果を優先します。Renovate はこの結果を CheckRun または
+commit StatusContext として出すことがあります。組み込み check/status が成功済みなら
 custom check も success、まだ完了していなければ custom check も pending のままです。
 
 ## release metadata の扱い
@@ -86,9 +87,9 @@ Worker が利用する変数・シークレット:
   HS256 shared secret を兼ねる秘密鍵
 - `GITHUB_APP_WEBHOOK_SECRET`: `X-Hub-Signature-256` 検証用シークレット
 
-GitHub App には、対象リポジトリの installation 情報を読める権限と、
-Checks を更新できる権限が必要です。Renovate 後続 workflow 側にも同じ
-秘密鍵を `PRIVATE_KEY` として渡し、互換性のある pending-state JWT を
+GitHub App には、対象リポジトリの installation 情報を読める権限、Checks を
+更新できる権限、Commit statuses を読める権限が必要です。Renovate 後続 workflow
+側にも同じ秘密鍵を `PRIVATE_KEY` として渡し、互換性のある pending-state JWT を
 生成できるようにしてください。
 
 ## ローカル検証

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -38,9 +38,9 @@ const INITIAL_QUEUE_SUMMARY =
 const INVALID_METADATA_SUMMARY =
 	"Pending state metadata could not be validated; waiting for the Renovate follow-up workflow to refresh it.";
 const BUILTIN_CHECK_SUMMARY =
-	"Renovate's built-in stability-days check exists on this commit.";
+	"Renovate's built-in stability-days check/status exists on this commit.";
 const BUILTIN_CHECK_PENDING_SUMMARY =
-	"Renovate's built-in stability-days check has not passed on this commit yet.";
+	"Renovate's built-in stability-days check/status has not passed on this commit yet.";
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
@@ -261,14 +261,30 @@ async function reevaluateCheckRun(
 		target.headSha,
 		installationToken,
 	);
+	const commitStatuses = await listCommitStatuses(
+		target.repositoryFullName,
+		target.headSha,
+		installationToken,
+	);
 
 	const existingCheckRun = findLatestCheckRun(checkRuns, CHECK_NAME);
 
-	// If the built-in Renovate stability-days check exists, mirror its state.
+	// If the built-in Renovate stability-days check/status exists, mirror its state.
 	const builtInCheckRun = findLatestCheckRun(checkRuns, BUILTIN_CHECK_NAME);
+	const builtInCommitStatus = findLatestCommitStatus(
+		commitStatuses,
+		BUILTIN_CHECK_NAME,
+	);
 
 	if (builtInCheckRun) {
 		const plan = checkRunHasPassingConclusion(builtInCheckRun)
+			? builtinSuccessPlan(target, BUILTIN_CHECK_SUMMARY)
+			: builtinPendingPlan(target);
+		return { plan, existingCheckRun };
+	}
+
+	if (builtInCommitStatus) {
+		const plan = commitStatusHasPassingState(builtInCommitStatus)
 			? builtinSuccessPlan(target, BUILTIN_CHECK_SUMMARY)
 			: builtinPendingPlan(target);
 		return { plan, existingCheckRun };
@@ -385,13 +401,17 @@ function checkRunMatchesPlan(checkRun: CheckRun, plan: CheckRunPlan): boolean {
 	);
 }
 
-function checkRunHasPassingConclusion(checkRun: CheckRun): boolean {
+function checkRunHasPassingConclusion(checkRun: CheckRun | null): boolean {
 	return (
-		checkRun.status === "completed" &&
+		checkRun?.status === "completed" &&
 		["success", "neutral", "skipped"].includes(
-			String(checkRun.conclusion ?? "").toLowerCase(),
+			String(checkRun?.conclusion ?? "").toLowerCase(),
 		)
 	);
+}
+
+function commitStatusHasPassingState(status: CommitStatus | null): boolean {
+	return String(status?.state ?? "").toLowerCase() === "success";
 }
 
 function builtinPendingPlan(target: CheckRunTarget): CheckRunPlan {
@@ -434,6 +454,35 @@ function findLatestCheckRun(
 	return latest;
 }
 
+function findLatestCommitStatus(
+	statuses: CommitStatus[],
+	context: string,
+): CommitStatus | null {
+	let latest: CommitStatus | null = null;
+	for (const status of statuses) {
+		if (status.context !== context) continue;
+		if (!latest || compareCommitStatuses(status, latest) > 0) {
+			latest = status;
+		}
+	}
+	return latest;
+}
+
+function compareCommitStatuses(
+	left: CommitStatus,
+	right: CommitStatus,
+): number {
+	const timestampDelta =
+		commitStatusTimestamp(left) - commitStatusTimestamp(right);
+	if (timestampDelta !== 0) return timestampDelta;
+	return (left.id ?? 0) - (right.id ?? 0);
+}
+
+function commitStatusTimestamp(status: CommitStatus): number {
+	const timestamp = new Date(status.updated_at ?? status.created_at ?? "");
+	return Number.isNaN(timestamp.getTime()) ? 0 : timestamp.getTime();
+}
+
 async function listCheckRuns(
 	repositoryFullName: string,
 	headSha: string,
@@ -454,6 +503,19 @@ async function listCheckRuns(
 		if (pageRuns.length < CHECK_RUNS_PAGE_SIZE) break;
 	}
 	return all;
+}
+
+async function listCommitStatuses(
+	repositoryFullName: string,
+	headSha: string,
+	installationToken: string,
+): Promise<CommitStatus[]> {
+	const combinedStatus = await githubJsonRequest<{ statuses?: CommitStatus[] }>(
+		"GET",
+		`${GITHUB_API_BASE}/repos/${repositoryFullName}/commits/${headSha}/status`,
+		installationToken,
+	);
+	return combinedStatus.statuses ?? [];
 }
 
 async function getIssueLabels(
@@ -531,4 +593,13 @@ interface CheckRun {
 	status: string;
 	conclusion: string | null;
 	output: { summary: string; text?: string | null } | null;
+}
+
+interface CommitStatus {
+	id?: number;
+	context: string;
+	state: string;
+	created_at?: string;
+	updated_at?: string;
+	description?: string | null;
 }


### PR DESCRIPTION
Fixes the PR #460 retry after PR #462 reverted the first attempt due to the GitHub Checks API error `Invalid request. For 'properties/text', nil is not a string.`

What changed
- Omit `output.text` from GitHub Checks API payloads when the custom check has no signed pending-state token.
- Mirror built-in `renovate/stability-days` from a CheckRun first, and from the combined commit StatusContext only when no CheckRun exists.
- Use the combined commit status endpoint so the latest status per context is read without an unbounded pagination scan.
- Add regression coverage for success/pending StatusContexts, null descriptions, CheckRun-over-status precedence, and text-field omission.
- Document the CheckRun/StatusContext behavior and needed Commit statuses permission.

Validation
- git --no-pager diff --check
- node --test .github/scripts/renovate-repositories.test.js .github/scripts/renovate-stability-days.test.js
- npx --yes -p node@22 -p npm@10 --c 'cd worker && npm run typecheck && npm test && timeout 300 npm run build'
- Review coordinator: no actionable issues after final fixes
