### PR TITLE
Fix Renovate GitHub API retries

### DIFF
--- a/.github/scripts/renovate-repositories.test.js
+++ b/.github/scripts/renovate-repositories.test.js
@@ -461,6 +461,29 @@ test("requests write access for commit statuses in the Renovate workflow", () =>
 	assert.doesNotMatch(workflow, /permission-statuses:\s*read(?:\s|$)/);
 });
 
+test("retries transient GitHub API failures in Renovate workflow script steps", () => {
+	const workflow = fs.readFileSync(
+		path.join(__dirname, "../workflows/renovate.yaml"),
+		"utf8",
+	);
+	const githubScriptStepBlocks = workflow
+		.split(/\n(?=\s+- name: )/)
+		.filter((block) => block.includes("uses: actions/github-script@"));
+	const githubScriptUseCount =
+		workflow.match(/^\s+uses:\s*actions\/github-script@/gm)?.length ?? 0;
+
+	assert.equal(githubScriptUseCount, 4);
+	assert.equal(githubScriptStepBlocks.length, 4);
+	assert.equal(githubScriptStepBlocks.length, githubScriptUseCount);
+	for (const block of githubScriptStepBlocks) {
+		assert.match(block, /^\s+retries:\s*3$/m);
+		assert.match(
+			block,
+			/^\s+retry-exempt-status-codes:\s*400,401,403,404,422$/m,
+		);
+	}
+});
+
 test("passes Renovate JSON logs through the GitHub Action container", () => {
 	const workflow = fs.readFileSync(
 		path.join(__dirname, "../workflows/renovate.yaml"),

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const path = require("node:path");
             const {
@@ -127,6 +129,8 @@ jobs:
             ${{ needs.enumerate_repositories.outputs.selection_map }}
         with:
           github-token: ${{ steps.get_repository_list_token.outputs.token }}
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const path = require("node:path");
             const {
@@ -204,6 +208,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const path = require("node:path");
             const {
@@ -300,6 +306,8 @@ jobs:
           SHARED_SECRET: ${{ secrets.PRIVATE_KEY }}
         with:
           github-token: ${{ steps.get_token.outputs.token }}
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const path = require("node:path");
             const {


### PR DESCRIPTION
## Summary
- Enable actions/github-script retries for the Renovate workflow script steps.
- Keep 400, 401, 403, 404, and 422 exempt so permanent auth/validation failures are not masked.
- Add a workflow regression test that ensures every github-script step keeps the retry config.

## Cause
Run 25742195722 / job 75595471045 failed when the custom stability-days reconcile step read check runs and GitHub returned a transient 500/socket failure (HttpError: other side closed, UND_ERR_SOCKET). The step was running with retries: 0, so the transient REST API failure terminated the job.

## Tests
- git --no-pager diff --check
- node --test .github/scripts/renovate-repositories.test.js .github/scripts/renovate-stability-days.test.js