### PR TITLE
fix(renovate): skip repositories with pull requests disabled

### DIFF
--- a/.github/scripts/renovate-repositories.js
+++ b/.github/scripts/renovate-repositories.js
@@ -101,6 +101,13 @@ const inspectRepositoryCandidate = ({ repository, owner } = {}) => {
 		};
 	}
 
+	if (repository?.has_pull_requests === false) {
+		return {
+			candidate: false,
+			reason: "pull requests are disabled in the repository",
+		};
+	}
+
 	return {
 		candidate: true,
 		reason: "repository is active for the workflow owner",

--- a/.github/scripts/renovate-repositories.test.js
+++ b/.github/scripts/renovate-repositories.test.js
@@ -58,16 +58,26 @@ test("filters to non-archived repositories for the current owner and sorts them"
 				archived: true,
 				disabled: false,
 			},
-			{
-				id: 4,
-				name: "external",
-				full_name: "another-org/external",
-				owner: { login: "another-org" },
-				archived: false,
-				disabled: false,
-			},
-		],
-	});
+{
+			id: 4,
+			name: "external",
+			full_name: "another-org/external",
+			owner: { login: "another-org" },
+			archived: false,
+			disabled: false,
+		},
+		{
+			id: 5,
+			name: "pulls-disabled",
+			full_name: "octo-org/pulls-disabled",
+			owner: { login: "octo-org" },
+			archived: false,
+			disabled: false,
+			has_issues: true,
+			has_pull_requests: false,
+		},
+	],
+});
 
 	assert.deepEqual(
 		filteredRepositories.map((repository) => repository.full_name),
@@ -89,6 +99,24 @@ test("inspects candidate repositories with explicit skip reasons", () => {
 		{
 			candidate: false,
 			reason: "repository is archived",
+		},
+	);
+
+	assert.deepEqual(
+		inspectRepositoryCandidate({
+			owner: "octo-org",
+			repository: {
+				full_name: "octo-org/pulls-disabled",
+				owner: { login: "octo-org" },
+				archived: false,
+				disabled: false,
+				has_issues: true,
+				has_pull_requests: false,
+			},
+		}),
+		{
+			candidate: false,
+			reason: "pull requests are disabled in the repository",
 		},
 	);
 });

--- a/.github/scripts/renovate-stability-days.js
+++ b/.github/scripts/renovate-stability-days.js
@@ -1087,15 +1087,29 @@ const processRepositoryRenovatePullRequests = async ({
 		);
 	}
 
-	const pullRequests = await github.paginate(
-		"GET /repos/{owner}/{repo}/pulls",
-		{
-			owner,
-			repo,
-			state: "open",
-			per_page: 100,
-		},
-	);
+	let pullRequests;
+	try {
+		pullRequests = await github.paginate(
+			"GET /repos/{owner}/{repo}/pulls",
+			{
+				owner,
+				repo,
+				state: "open",
+				per_page: 100,
+			},
+		);
+	} catch (error) {
+		if (error?.status !== 404) {
+			throw error;
+		}
+
+		effectiveLogger.warn?.(
+			`Pull requests are disabled or inaccessible for ${owner}/${repo}; ` +
+				`skipping custom stability-days check reconciliation ` +
+				`(status: ${error?.status ?? "unknown"}).`,
+		);
+		return [];
+	}
 	const renovatePullRequests = pullRequests.filter((pullRequest) =>
 		String(pullRequest?.head?.ref ?? "").startsWith("renovate/"),
 	);

--- a/.github/scripts/renovate-stability-days.test.js
+++ b/.github/scripts/renovate-stability-days.test.js
@@ -1586,6 +1586,56 @@ test("processes only renovate pull requests when scanning a repository", async (
 	);
 });
 
+test("skips reconciliation when pull requests are disabled for the repository", async () => {
+	const warnings = [];
+	const github = {
+		async paginate() {
+			const error = new Error("Not Found");
+			error.status = 404;
+			throw error;
+		},
+	};
+
+	const results = await processRepositoryRenovatePullRequests({
+		github,
+		owner: "octo-org",
+		repo: "pulls-disabled",
+		secret: "secret",
+		now: new Date("2026-05-01T12:00:00Z"),
+		logger: {
+			warn(message) {
+				warnings.push(message);
+			},
+		},
+	});
+
+	assert.deepEqual(results, []);
+	assert.equal(warnings.length, 1);
+	assert.match(
+		warnings[0],
+		/Pull requests are disabled or inaccessible for octo-org\/pulls-disabled/,
+	);
+});
+
+test("rethrows non-404 failures when listing repository pull requests", async () => {
+	const github = {
+		async paginate() {
+			throw new Error("Unexpected failure");
+		},
+	};
+
+	await assert.rejects(
+		processRepositoryRenovatePullRequests({
+			github,
+			owner: "octo-org",
+			repo: "example",
+			secret: "secret",
+			now: new Date("2026-05-01T12:00:00Z"),
+		}),
+		/Unexpected failure/,
+	);
+});
+
 test("warns when a reusable pending token can no longer be decoded", async () => {
 	const warnings = [];
 	const github = {


### PR DESCRIPTION
## Problem

The Renovate workflow (`Renovate` → `Self-hosted Renovate (private-*)`) has been failing for every run with:

```
Unhandled error: HttpError: Not Found - https://docs.github.com/rest/pulls/pulls#list-pull-requests
```

in the `Reconcile custom stability-days checks` step, plus a `HTTPError 404` from the `Self-hosted Renovate` step itself (`GET /repos/{owner}/{repo}/pulls`).

## Root cause

GitHub added a repository setting that **disables pull requests entirely**. When enabled, the REST endpoint `GET /repos/{owner}/{repo}/pulls` returns **404 for everyone** (owner and app tokens alike) and the pull requests tab is hidden.

The affected repositories — `rust-qif`, `rustIpam`, `rusvault`, `study-raft` — have this setting enabled (`has_pull_requests: false`), so:

- Renovate cannot list pull requests during platform initialization → host error 404
- The follow-up stability-days reconciliation cannot list pull requests → unhandled 404

All other repositories have pull requests enabled and succeed.

## Fix

1. **`.github/scripts/renovate-repositories.js`** — `inspectRepositoryCandidate` now rejects repositories where `has_pull_requests === false` (reason: "pull requests are disabled in the repository"). Such repositories are filtered out during repository enumeration, so they no longer appear in the workflow matrix at all.
2. **`.github/scripts/renovate-stability-days.js`** — `processRepositoryRenovatePullRequests` now tolerates a 404 when listing pull requests and skips reconciliation with a warning instead of crashing (safety net for any repository where the setting changes after enumeration).

## Notes

- If these repositories should keep receiving Renovate updates, re-enable **Pull requests** in their settings (Settings → General → Features) — the setting itself is web-UI-only and cannot be changed via the API.
- Tests: `node --test .github/scripts/renovate-repositories.test.js .github/scripts/renovate-stability-days.test.js` and `npm test` in `worker/` all pass.